### PR TITLE
fix: add id-token: write permission to monitor-changelog workflow

### DIFF
--- a/.github/workflows/monitor-changelog.yml
+++ b/.github/workflows/monitor-changelog.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   check-changelog:


### PR DESCRIPTION
## Summary
- `monitor-changelog.yml` ワークフローの `permissions` に `id-token: write` を追加
- `anthropics/claude-code-action@v1` がOIDCトークンを取得するために必要な権限が不足していたため、ワークフロー実行時にエラーが発生していた

## Test plan
- [ ] `monitor-changelog` ワークフローを `workflow_dispatch` で手動実行し、OIDCトークンエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)