### PR TITLE
fix: use claude_code_oauth_token instead of anthropic_api_key

### DIFF
--- a/.github/workflows/monitor-changelog.yml
+++ b/.github/workflows/monitor-changelog.yml
@@ -75,7 +75,7 @@ jobs:
             6. すべて日本語で記述してください
             7. 変更をコミットしてください
 
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Edit,Write,Bash(git commit:*),Bash(git add:*),Bash(date:*),Read,Glob,WebSearch,WebFetch"
 
       - name: Update last-known changelog


### PR DESCRIPTION
Switch authentication method to match other workflows (claude.yml, claude-code-review.yml) and use the configured CLAUDE_CODE_OAUTH_TOKEN secret.