### PR TITLE
fix: re-establish git credentials before push in monitor-changelog wo…

### DIFF
--- a/.github/workflows/monitor-changelog.yml
+++ b/.github/workflows/monitor-changelog.yml
@@ -85,4 +85,8 @@ jobs:
           git diff --cached --quiet || git commit -m "Update last-known changelog"
 
       - name: Push changes
-        run: git push
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…rkflow

Claude Code action resets git authentication, causing subsequent git push to fail. Explicitly set remote URL with GITHUB_TOKEN.