### PR TITLE
fix: monitor-changelog workflow の認証とツール設定を修正

### DIFF
--- a/.github/workflows/monitor-changelog.yml
+++ b/.github/workflows/monitor-changelog.yml
@@ -76,7 +76,7 @@ jobs:
             7. 変更をコミットしてください
 
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: "Edit,Write,Bash(git commit:*),Bash(git add:*),Bash(date:*),Read,Glob,WebSearch,WebFetch"
+          claude_args: "--allowedTools Edit,Write,\"Bash(git commit:*)\",\"Bash(git add:*)\",\"Bash(date:*)\",Read,Glob,WebSearch,WebFetch"
 
       - name: Update last-known changelog
         run: |


### PR DESCRIPTION
## Summary
- Claude Code action 実行後に git 認証情報が失われる問題を修正（`git remote set-url` で `GITHUB_TOKEN` を明示的に設定）
- `allowed_tools` が `claude-code-action@v1` の無効なパラメータだったため、`claude_args` の `--allowedTools` に移行

## Test plan
- [ ] `workflow_dispatch` で手動実行し、ガイド記事が生成・コミット・push されることを確認
- [ ] Pages デプロイがトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)