### PR TITLE
fix: アップデート一覧の日付表示のタイムゾーンずれを修正

### DIFF
--- a/docs/updates/index.data.mts
+++ b/docs/updates/index.data.mts
@@ -7,5 +7,23 @@ export default createContentLoader('updates/*.md', {
       .sort((a, b) => {
         return +new Date(b.frontmatter.date) - +new Date(a.frontmatter.date)
       })
+      .map(page => ({
+        ...page,
+        frontmatter: {
+          ...page.frontmatter,
+          date: formatDate(page.frontmatter.date)
+        }
+      }))
   }
 })
+
+function formatDate(date: string | Date): string {
+  if (typeof date === 'string') {
+    return date.slice(0, 10)
+  }
+  // Date オブジェクトの場合、UTC年月日を取得（タイムゾーンずれ防止）
+  const y = date.getUTCFullYear()
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}


### PR DESCRIPTION
## Summary
- data loaderでfrontmatterの`date`をUTC基準の`YYYY-MM-DD`文字列に変換してからクライアントに返すように修正
- YAMLパーサーが`Date`オブジェクト（UTC midnight）に変換した日付が、JST環境のブラウザで前日として表示される問題を解消

## Test plan
- [ ] `npm run docs:dev` でローカルサーバーを起動
- [ ] `/updates/` ページで各記事の日付がfrontmatterの値と一致することを確認
- [ ] `npm run docs:build` がエラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)