### PR TITLE
fix: disable-experimental-betas記事の日付を01-30に修正

### DIFF
--- a/docs/updates/2026-01-30-disable-experimental-betas.md
+++ b/docs/updates/2026-01-30-disable-experimental-betas.md
@@ -1,6 +1,6 @@
 ---
 title: "Bedrock・Vertex環境での実験的機能の無効化"
-date: 2026-01-29
+date: 2026-01-30
 tags: [bedrock, vertex, environment-variables, troubleshooting]
 ---
 


### PR DESCRIPTION
## Summary
- `2026-01-29-disable-experimental-betas.md` のファイル名と frontmatter の date を `2026-01-30` に修正
- 記事が1月30日分として生成されたが、日付が誤って1月29日になっていた

## Test plan
- [ ] `/updates/` ページで「Bedrock・Vertex環境での実験的機能の無効化」の日付が `2026-01-30` と表示されることを確認
- [ ] サイドバーのリンクが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)