### PR TITLE
chore: change workflow schedule to JST 07:00

### DIFF
--- a/.github/workflows/monitor-changelog.yml
+++ b/.github/workflows/monitor-changelog.yml
@@ -2,8 +2,8 @@ name: Monitor Changelog & Generate Guide
 
 on:
   schedule:
-    # 毎日00:00 UTC（JST 09:00）に実行
-    - cron: '0 0 * * *'
+    # 毎日22:00 UTC（JST 07:00）に実行
+    - cron: '0 22 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- GitHub Actionsのスケジュールを日本時間の毎朝7時（UTC 22:00）に変更
- Claude Codeのアップデートが6時前に行われても7時の実行で検知できるようにするため

## Test plan
- [ ] ワークフローファイルの構文が正しいことを確認
- [ ] スケジュール設定が意図通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)