### PR TITLE
feat: implement card-based layout on homepage

### DIFF
--- a/docs/.vitepress/components/ArticleCard.vue
+++ b/docs/.vitepress/components/ArticleCard.vue
@@ -1,0 +1,116 @@
+<template>
+  <a :href="url" class="article-card">
+    <h3 class="title">{{ title }}</h3>
+    <div class="date">{{ date }}</div>
+    <p class="excerpt">{{ excerpt }}</p>
+    <div class="tags">
+      <span v-for="tag in tags" :key="tag" class="tag" :style="getTagStyle(tag)">
+        {{ tag }}
+      </span>
+    </div>
+    <div class="read-more">続きを読む →</div>
+  </a>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  url: string
+  title: string
+  date: string
+  excerpt: string
+  tags?: string[]
+}
+
+defineProps<Props>()
+
+// タグの色分け（ハッシュベースで5色をローテーション）
+const tagColors = [
+  { color: '#3b82f6', bg: 'rgba(59, 130, 246, 0.1)' },   // blue
+  { color: '#22c55e', bg: 'rgba(34, 197, 94, 0.1)' },    // green
+  { color: '#a855f7', bg: 'rgba(168, 85, 247, 0.1)' },   // purple
+  { color: '#f97316', bg: 'rgba(249, 115, 22, 0.1)' },   // orange
+  { color: '#ec4899', bg: 'rgba(236, 72, 153, 0.1)' }    // pink
+]
+
+function getTagStyle(tag: string) {
+  const hash = tag.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  const colorIndex = hash % tagColors.length
+  const { color, bg } = tagColors[colorIndex]
+  return {
+    color,
+    backgroundColor: bg,
+    borderColor: color
+  }
+}
+</script>
+
+<style scoped>
+.article-card {
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background-color: var(--vp-c-bg-soft);
+  text-decoration: none;
+  color: inherit;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  height: 100%;
+}
+
+.article-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  border-color: var(--vp-c-brand-1);
+}
+
+.title {
+  margin: 0 0 8px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+}
+
+.date {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+}
+
+.excerpt {
+  margin: 0 0 16px 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  flex-grow: 1;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.tag {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid;
+  font-weight: 500;
+}
+
+.read-more {
+  margin-top: auto;
+  font-size: 14px;
+  color: var(--vp-c-brand-1);
+  font-weight: 500;
+  transition: text-decoration 0.2s;
+}
+
+.article-card:hover .read-more {
+  text-decoration: underline;
+}
+</style>

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -31,8 +31,7 @@ export default defineConfig({
   lang: 'ja',
   themeConfig: {
     nav: [
-      { text: 'ホーム', link: '/' },
-      { text: 'アップデート', link: '/updates/' }
+      { text: 'ホーム', link: '/' }
     ],
     sidebar: [
       {

--- a/docs/.vitepress/loaders/updates.data.mts
+++ b/docs/.vitepress/loaders/updates.data.mts
@@ -12,7 +12,8 @@ export default createContentLoader('updates/*.md', {
         frontmatter: {
           ...page.frontmatter,
           date: formatDate(page.frontmatter.date)
-        }
+        },
+        excerpt: extractExcerpt(page.html)
       }))
   }
 })
@@ -26,4 +27,29 @@ function formatDate(date: string | Date): string {
   const m = String(date.getUTCMonth() + 1).padStart(2, '0')
   const d = String(date.getUTCDate()).padStart(2, '0')
   return `${y}-${m}-${d}`
+}
+
+function extractExcerpt(html: string | undefined): string {
+  if (!html) return ''
+
+  // HTMLタグを除去
+  const text = html.replace(/<[^>]*>/g, ' ')
+
+  // 連続空白を1つに正規化
+  const normalized = text.replace(/\s+/g, ' ').trim()
+
+  // 文単位で分割（句点、感嘆符、疑問符で判定）
+  const sentences = normalized.split(/[。！？]/)
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+
+  // 最初の2文を結合
+  let excerpt = sentences.slice(0, 2).join('。') + '。'
+
+  // 150字を超える場合は切り詰めて「...」を追加
+  if (excerpt.length > 150) {
+    excerpt = excerpt.slice(0, 147) + '...'
+  }
+
+  return excerpt
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,6 @@ hero:
   tagline: Claude Codeのchangelogを自動監視し、新機能の活用方法を日本語で解説します
   actions:
     - theme: brand
-      text: アップデート一覧
-      link: /updates/
-    - theme: alt
       text: Claude Code公式
       link: https://github.com/anthropics/claude-code
 features:
@@ -19,3 +16,65 @@ features:
   - title: 日本語対応
     details: すべてのガイドは日本語で記述され、具体的なコード例を含みます
 ---
+
+<script setup>
+import { data as updates } from './.vitepress/loaders/updates.data.mts'
+import ArticleCard from './.vitepress/components/ArticleCard.vue'
+</script>
+
+<div class="updates-section">
+  <h2 class="section-title">最新アップデート</h2>
+  <div class="updates-grid">
+    <ArticleCard
+      v-for="update in updates"
+      :key="update.url"
+      :url="update.url"
+      :title="update.frontmatter.title"
+      :date="update.frontmatter.date"
+      :excerpt="update.excerpt"
+      :tags="update.frontmatter.tags"
+    />
+  </div>
+</div>
+
+<style scoped>
+.updates-section {
+  max-width: 1400px;
+  margin: 64px auto;
+  padding: 0 24px;
+}
+
+.section-title {
+  font-size: 32px;
+  font-weight: 700;
+  margin: 0 0 32px 0;
+  color: var(--vp-c-text-1);
+  text-align: center;
+}
+
+.updates-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .updates-section {
+    padding: 0 48px;
+  }
+
+  .updates-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 960px) {
+  .updates-section {
+    padding: 0 64px;
+  }
+
+  .updates-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+</style>

--- a/docs/updates/index.md
+++ b/docs/updates/index.md
@@ -1,30 +1,19 @@
 ---
 layout: page
-title: アップデート一覧
 ---
 
 <script setup>
-import { data } from './index.data.mts'
-import { withBase } from 'vitepress'
+import { onMounted } from 'vue'
+import { useRouter } from 'vitepress'
+
+const router = useRouter()
+onMounted(() => {
+  router.go('/')
+})
 </script>
 
-# アップデート一覧
+# リダイレクト中...
 
-Claude Codeの新機能・アップデートに関するガイド記事の一覧です。
+このページは新しいトップページに統合されました。自動的にリダイレクトします。
 
-<div v-for="article of data" :key="article.url" class="article-item">
-  <h3><a :href="withBase(article.url)" class="article-link">{{ article.frontmatter.title }}</a></h3>
-  <p class="date">{{ article.frontmatter.date }}</p>
-  <p v-if="article.frontmatter.tags" class="tags">
-    <span v-for="tag in article.frontmatter.tags" :key="tag" class="tag">{{ tag }}</span>
-  </p>
-</div>
-
-<style>
-.article-item { margin-bottom: 1.5rem; }
-.article-link { color: var(--vp-c-brand-1); text-decoration: underline; }
-.article-link:hover { color: var(--vp-c-brand-2); }
-.date { color: var(--vp-c-text-2); font-size: 0.9em; margin: 0.25rem 0; }
-.tags { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-.tag { background: var(--vp-c-bg-soft); padding: 0.1rem 0.5rem; border-radius: 4px; font-size: 0.85em; }
-</style>
+[トップページへ](/)


### PR DESCRIPTION
## 概要

トップページをカード型レイアウトに刷新し、アップデート記事を直接表示できるようにしました。これにより、ユーザーは `/updates/` への遷移なしに即座にアップデート内容を把握できます。

## 主な変更

### 新規作成
- `docs/.vitepress/components/ArticleCard.vue` - カード型コンポーネント
  - ホバー時の浮き上がりアニメーション（4px）
  - タグの色分け（ハッシュベースで5色ローテーション）
  - レスポンシブデザイン対応
- `docs/.vitepress/loaders/updates.data.mts` - 拡張版コンテンツローダー
  - 概要自動抽出機能（HTMLから最初の2文、最大150字）

### 変更
- `docs/index.md` - トップページにカード一覧を統合
- `docs/.vitepress/config.mts` - ナビゲーションから「アップデート」リンクを削除
- `docs/updates/index.md` - トップページへのリダイレクトページに変更

### デザイン仕様
- **レスポンシブグリッド**: モバイル1カラム、タブレット2カラム、デスクトップ3カラム
- **ホバーエフェクト**: 4px浮き上がり、シャドウ、ボーダーカラー変化
- **タグカラー**: 5色（青、緑、紫、オレンジ、ピンク）をハッシュベースでローテーション

## 検証

- ✅ ビルド成功（エラーなし）
- ✅ レスポンシブレイアウト動作確認
- ✅ リダイレクト動作確認
- ✅ 個別記事ページ正常表示

Resolves #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)