### PR TITLE
fix: add withBase to article card links

### DIFF
--- a/docs/.vitepress/components/ArticleCard.vue
+++ b/docs/.vitepress/components/ArticleCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="url" class="article-card">
+  <a :href="withBase(url)" class="article-card">
     <h3 class="title">{{ title }}</h3>
     <div class="date">{{ date }}</div>
     <p class="excerpt">{{ excerpt }}</p>
@@ -13,6 +13,8 @@
 </template>
 
 <script setup lang="ts">
+import { withBase } from 'vitepress'
+
 interface Props {
   url: string
   title: string


### PR DESCRIPTION
404エラーを修正。VitePressのwithBase()を使用してbaseパスを自動追加。