### PR TITLE
fix: use Personal Access Token for GitHub Actions push

### DIFF
--- a/.github/workflows/monitor-changelog.yml
+++ b/.github/workflows/monitor-changelog.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Push changes
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${PAT_TOKEN}@github.com/${{ github.repository }}.git"
           git push
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace GITHUB_TOKEN with PAT_TOKEN secret in workflow
- Enables workflow to push changes without permission errors
- Resolves #18

## Changes
- Modified `.github/workflows/monitor-changelog.yml` to use `PAT_TOKEN` instead of `GITHUB_TOKEN`

## Setup Required
After merging, repository admin needs to:
1. Create Fine-grained PAT with `contents: write` and `workflows: write` permissions
2. Add as repository secret named `PAT_TOKEN`

## Test plan
- [ ] Create PAT with required permissions
- [ ] Add PAT_TOKEN to repository secrets
- [ ] Trigger workflow manually to verify push works

🤖 Generated with [Claude Code](https://claude.com/claude-code)