### PR TITLE
fix: remove .md extension from internal links

### DIFF
--- a/docs/updates/2026-01-31-auto-pr-session-linking.md
+++ b/docs/updates/2026-01-31-auto-pr-session-linking.md
@@ -119,5 +119,5 @@ claude --from-pr 123
 ## 関連情報
 
 - [Claude Code公式ドキュメント](https://docs.claude.ai/claude-code)
-- [--from-pr フラグの使い方](/docs/updates/2026-01-31-from-pr-flag.md)
+- [--from-pr フラグの使い方](./2026-01-31-from-pr-flag)
 - [GitHub CLI (gh) ドキュメント](https://cli.github.com/)

--- a/docs/updates/2026-01-31-improved-permission-control.md
+++ b/docs/updates/2026-01-31-improved-permission-control.md
@@ -115,4 +115,4 @@ Claude Code 2.1.27で、パーミッション設定の動作が改善されま�
 ## 関連情報
 
 - [Claude Code公式ドキュメント](https://docs.claude.ai/claude-code)
-- [権限管理の強化：ワイルドカード許可とCLAUDE.md](/docs/updates/2026-01-27-permissions-and-claude-md.md)
+- [権限管理の強化：ワイルドカード許可とCLAUDE.md](./2026-01-27-permissions-and-claude-md)


### PR DESCRIPTION
VitePress requires internal links without .md extension to avoid dead link errors.