### PR TITLE
fix: correct YAML frontmatter quotes to prevent parse errors

### DIFF
--- a/docs/updates/2026-01-31-v2-1-0-100-interrupted-message-color-from-red-to-grey-for-a-less-alar.md
+++ b/docs/updates/2026-01-31-v2-1-0-100-interrupted-message-color-from-red-to-grey-for-a-less-alar.md
@@ -1,5 +1,5 @@
 ---
-title: "変更 "Interrupted" message color from red to grey for a les..."
+title: '変更 "Interrupted" message color from red to grey for a less alarming appearance'
 date: 2026-01-07
 tags: ['変更']
 ---

--- a/docs/updates/2026-01-31-v2-1-0-16-background-tasks-failing-with-git-repository-not-found-err.md
+++ b/docs/updates/2026-01-31-v2-1-0-16-background-tasks-failing-with-git-repository-not-found-err.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 background tasks failing with "git repository not foun..."
+title: '修正 background tasks failing with "git repository not foun...'
 date: 2026-01-07
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-0-64-forked-slash-commands-showing-aborterror-instead-of-inter.md
+++ b/docs/updates/2026-01-31-v2-1-0-64-forked-slash-commands-showing-aborterror-instead-of-inter.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 forked slash commands showing "AbortError" instead of ..."
+title: '修正 forked slash commands showing "AbortError" instead of ...'
 date: 2026-01-07
 tags: ['バグ修正', 'コマンド']
 ---

--- a/docs/updates/2026-01-31-v2-1-0-67-images-in-queued-prompts-showing-as-object-object-when-p.md
+++ b/docs/updates/2026-01-31-v2-1-0-67-images-in-queued-prompts-showing-as-object-object-when-p.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 images in queued prompts showing as "[object Object]" ..."
+title: '修正 images in queued prompts showing as "[object Object]" ...'
 date: 2026-01-07
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-0-69-large-pasted-images-failing-with-image-was-too-large-error.md
+++ b/docs/updates/2026-01-31-v2-1-0-69-large-pasted-images-failing-with-image-was-too-large-error.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 large pasted images failing with "Image was too large"..."
+title: '修正 large pasted images failing with "Image was too large"...'
 date: 2026-01-07
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-0-72-collapsed-reading-x-files-indicator-incorrectly-switching.md
+++ b/docs/updates/2026-01-31-v2-1-0-72-collapsed-reading-x-files-indicator-incorrectly-switching.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 collapsed "Reading X files…" indicator incorrectly swi..."
+title: '修正 collapsed "Reading X files…" indicator incorrectly swi...'
 date: 2026-01-07
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-0-76-race-condition-where-lsp-tool-could-return-no-server-availa.md
+++ b/docs/updates/2026-01-31-v2-1-0-76-race-condition-where-lsp-tool-could-return-no-server-availa.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 race condition where LSP tool could return "no server ..."
+title: '修正 race condition where LSP tool could return "no server ...'
 date: 2026-01-07
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-15-2-the-context-left-until-auto-compact-warning-not-disappeari.md
+++ b/docs/updates/2026-01-31-v2-1-15-2-the-context-left-until-auto-compact-warning-not-disappeari.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 the "Context left until auto-compact" warning not disa..."
+title: '修正 the "Context left until auto-compact" warning not disa...'
 date: 2026-01-21
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-16-4-an-issue-where-the-context-remaining-warning-was-not-hidde.md
+++ b/docs/updates/2026-01-31-v2-1-16-4-an-issue-where-the-context-remaining-warning-was-not-hidde.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 an issue where the "context remaining" warning was not..."
+title: '修正 an issue where the "context remaining" warning was not...'
 date: 2026-01-22
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-19-7-agent-list-displaying-sonnet-default-instead-of-inherit.md
+++ b/docs/updates/2026-01-31-v2-1-19-7-agent-list-displaying-sonnet-default-instead-of-inherit.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 agent list displaying "Sonnet (default)" instead of "I..."
+title: '修正 agent list displaying "Sonnet (default)" instead of "I...'
 date: 2026-01-23
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-20-21-collapsed-read-search-groups-to-show-present-tense-reading.md
+++ b/docs/updates/2026-01-31-v2-1-20-21-collapsed-read-search-groups-to-show-present-tense-reading.md
@@ -1,5 +1,5 @@
 ---
-title: "変更 collapsed read/search groups to show present tense ("R..."
+title: '変更 collapsed read/search groups to show present tense ("R...'
 date: 2026-01-27
 tags: ['変更']
 ---

--- a/docs/updates/2026-01-31-v2-1-21-6-read-search-progress-indicators-to-show-reading-while-in.md
+++ b/docs/updates/2026-01-31-v2-1-21-6-read-search-progress-indicators-to-show-reading-while-in.md
@@ -1,5 +1,5 @@
 ---
-title: "改善 read/search progress indicators to show "Reading…" whi..."
+title: '改善 read/search progress indicators to show "Reading…" whi...'
 date: 2026-01-28
 tags: ['改善']
 ---

--- a/docs/updates/2026-01-31-v2-1-4-1-help-improve-claude-setting-fetch-to-refresh-oauth-and-ret.md
+++ b/docs/updates/2026-01-31-v2-1-4-1-help-improve-claude-setting-fetch-to-refresh-oauth-and-ret.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 "Help improve Claude" setting fetch to refresh OAuth a..."
+title: '修正 "Help improve Claude" setting fetch to refresh OAuth a...'
 date: 2026-01-11
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-6-20-updated-help-improve-claude-setting-fetch-to-refresh-oauth.md
+++ b/docs/updates/2026-01-31-v2-1-6-20-updated-help-improve-claude-setting-fetch-to-refresh-oauth.md
@@ -1,5 +1,5 @@
 ---
-title: "Updated "Help improve Claude" setting fetch to refresh OA..."
+title: 'Updated "Help improve Claude" setting fetch to refresh OA...'
 date: 2026-01-13
 tags: ['その他']
 ---

--- a/docs/updates/2026-01-31-v2-1-6-22-terminal-title-to-claude-code-on-startup-for-better-window.md
+++ b/docs/updates/2026-01-31-v2-1-6-22-terminal-title-to-claude-code-on-startup-for-better-window.md
@@ -1,5 +1,5 @@
 ---
-title: "変更 terminal title to "Claude Code" on startup for better ..."
+title: '変更 terminal title to "Claude Code" on startup for better ...'
 date: 2026-01-13
 tags: ['変更']
 ---

--- a/docs/updates/2026-01-31-v2-1-6-7-false-file-has-been-unexpectedly-modified-errors-when-file.md
+++ b/docs/updates/2026-01-31-v2-1-6-7-false-file-has-been-unexpectedly-modified-errors-when-file.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 false "File has been unexpectedly modified" errors whe..."
+title: '修正 false "File has been unexpectedly modified" errors whe...'
 date: 2026-01-13
 tags: ['バグ修正']
 ---

--- a/docs/updates/2026-01-31-v2-1-7-4-false-file-modified-errors-on-windows-when-cloud-sync-tool.md
+++ b/docs/updates/2026-01-31-v2-1-7-4-false-file-modified-errors-on-windows-when-cloud-sync-tool.md
@@ -1,5 +1,5 @@
 ---
-title: "修正 false "file modified" errors on Windows when cloud syn..."
+title: '修正 false "file modified" errors on Windows when cloud syn...'
 date: 2026-01-14
 tags: ['バグ修正', 'Windows']
 ---

--- a/docs/updates/2026-01-31-v2-1-9-2-external-editor-support-ctrl-g-in-askuserquestion-other.md
+++ b/docs/updates/2026-01-31-v2-1-9-2-external-editor-support-ctrl-g-in-askuserquestion-other.md
@@ -1,5 +1,5 @@
 ---
-title: "追加 external editor support (Ctrl+G) in AskUserQuestion "O..."
+title: '追加 external editor support (Ctrl+G) in AskUserQuestion "O...'
 date: 2026-01-16
 tags: ['新機能']
 ---


### PR DESCRIPTION
- タイトル内のダブルクォートがYAMLパーサーエラーを引き起こしていた問題を修正
- 18ファイルのfrontmatterをダブルクォートからシングルクォートに変更
- VitePressビルドエラーを解決