### PR TITLE
fix: escape backslashes in Windows path in YAML frontmatter

### DIFF
--- a/docs/updates/2026-01-31-v2-1-2-19-windows-managed-settings-path-c-programdata-claudecode-man.md
+++ b/docs/updates/2026-01-31-v2-1-2-19-windows-managed-settings-path-c-programdata-claudecode-man.md
@@ -1,5 +1,5 @@
 ---
-title: "非推奨化 Windows managed settings path `C:\ProgramData\Claude..."
+title: '非推奨化 Windows managed settings path `C:\ProgramData\ClaudeCode\managed-settings.json`'
 date: 2026-01-09
 tags: ['Windows']
 ---


### PR DESCRIPTION
- Windowsパスのバックスラッシュが正しくエスケープされていなかった問題を修正
- シングルクォートを使用してバックスラッシュをリテラルとして扱う