### PR TITLE
fix: standardize article card heights

### DIFF
--- a/docs/.vitepress/components/ArticleCard.vue
+++ b/docs/.vitepress/components/ArticleCard.vue
@@ -72,6 +72,11 @@ function getTagStyle(tag: string) {
   font-weight: 600;
   color: var(--vp-c-text-1);
   line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 50px;
 }
 
 .date {


### PR DESCRIPTION
## Summary
- Fixed inconsistent card heights in the updates grid by limiting title display to 2 lines
- Added minimum height to title area for visual consistency

## Changes
- Added CSS `line-clamp` to limit titles to 2 lines with ellipsis overflow
- Set `min-height: 50px` on title elements to maintain uniform card heights
- Improved overall grid layout appearance

## Test plan
- [x] Build VitePress site successfully
- [x] Verify card heights are now consistent in the grid
- [x] Confirm long titles are properly truncated with ellipsis
- [x] Check hover states still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)