### PR TITLE
fix: prevent card width expansion in grid layout

### DIFF
--- a/docs/.vitepress/components/ArticleCard.vue
+++ b/docs/.vitepress/components/ArticleCard.vue
@@ -58,6 +58,7 @@ function getTagStyle(tag: string) {
   color: inherit;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   height: 100%;
+  min-height: 280px;
 }
 
 .article-card:hover {

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ import ArticleCard from './.vitepress/components/ArticleCard.vue'
   display: grid;
   gap: 24px;
   grid-template-columns: 1fr;
+  grid-auto-rows: 1fr;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
- Add grid-auto-rows: 1fr to ensure uniform row heights
- Set min-height: 280px on cards to maintain consistent sizing
- Fix issue where middle cards were expanding horizontally