### PR TITLE
fix: use auto-fill grid layout to prevent card stretching

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,6 @@ import ArticleCard from './.vitepress/components/ArticleCard.vue'
   display: grid;
   gap: 24px;
   grid-template-columns: 1fr;
-  grid-auto-rows: 1fr;
 }
 
 @media (min-width: 640px) {
@@ -65,7 +64,7 @@ import ArticleCard from './.vitepress/components/ArticleCard.vue'
   }
 
   .updates-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   }
 }
 
@@ -75,7 +74,7 @@ import ArticleCard from './.vitepress/components/ArticleCard.vue'
   }
 
   .updates-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
   }
 }
 </style>


### PR DESCRIPTION
- Change from fixed 3-column to responsive auto-fill layout
- Set minimum card width (300px/380px) with minmax()
- Cards now arrange naturally based on viewport width
- Prevents horizontal expansion of cards in grid