### PR TITLE
fix: correct dead link in agent memory persistence guide

### DIFF
--- a/docs/updates/2.1.33-agent-memory-persistence.md
+++ b/docs/updates/2.1.33-agent-memory-persistence.md
@@ -229,4 +229,4 @@ tools:
 - [Claude Agent SDK公式ドキュメント](https://docs.anthropic.com/claude/docs/agent-sdk)
 - [カスタムエージェントの作成ガイド](https://docs.anthropic.com/claude/docs/custom-agents)
 - [エージェントメモリのベストプラクティス](https://docs.anthropic.com/claude/docs/agent-memory)
-- [Auto Memoryガイド](/updates/auto-memory)
+- [Automatic Memoryガイド](/updates/2.1.32-automatic-memory)


### PR DESCRIPTION
/updates/auto-memory → /updates/2.1.32-automatic-memory