### PR TITLE
VitePressビルドエラー修正 - デッドリンクを公式ドキュメントURLに置き換え

### DIFF
--- a/docs/updates/2.1.41-rename-auto-generate.md
+++ b/docs/updates/2.1.41-rename-auto-generate.md
@@ -208,5 +208,5 @@ Claude Codeが会話の内容を分析し、適切なセッション名を提案
 
 ## 関連情報
 - [Claude Code公式ドキュメント](https://github.com/anthropics/claude-code)
-- [セッション管理のベストプラクティス](/docs/session-management.md)
+- [セッション管理（公式ドキュメント）](https://docs.anthropic.com/en/docs/claude-code/sessions)
 - `/resume`コマンドの活用ガイド

--- a/docs/updates/2.1.42-resume-fix.md
+++ b/docs/updates/2.1.42-resume-fix.md
@@ -105,5 +105,5 @@ claude
 
 ## 関連情報
 - [Claude Code公式ドキュメント](https://github.com/anthropics/claude-code)
-- [セッション管理のベストプラクティス](/docs/session-management.md)
+- [セッション管理（公式ドキュメント）](https://docs.anthropic.com/en/docs/claude-code/sessions)
 - `/rename`コマンドの活用ガイド


### PR DESCRIPTION
## 概要
VitePressビルドで発生していた「2 dead links found」エラーを修正しました。

## 変更内容
存在しない `/docs/session-management.md` へのリンクを公式ドキュメントURLに置き換えました。

### 修正ファイル
- `docs/updates/2.1.41-rename-auto-generate.md` (211行目)
- `docs/updates/2.1.42-resume-fix.md` (108行目)

### 変更後のリンク
`https://docs.anthropic.com/en/docs/claude-code/sessions`

## 検証
- ✅ `npm run docs:build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)