### PR TITLE
chore: ActionsのAPI従量課金フォールバック防止ガード追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,6 +50,10 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          # 課金ガード: OAuthトークン（サブスク認証）のみを使用する。
+          # 2026-06-15以降、GitHub Actions経由の実行は「Agent SDK クレジットプール」から消費される。
+          # anthropic_api_key は意図的に設定しない（設定するとクレジット枠超過時にAPI従量課金へ
+          # フォールバックするため）。リポジトリSecretsに ANTHROPIC_API_KEY を追加しないこと。
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs

--- a/.github/workflows/monitor-changelog.yml
+++ b/.github/workflows/monitor-changelog.yml
@@ -93,6 +93,12 @@ jobs:
             7. すべて日本語で記述してください
             8. 変更をコミットしてください
 
+          # 課金ガード: OAuthトークン（サブスク認証）のみを使用する。
+          # 2026-06-15以降、GitHub Actions経由のClaude Code実行はサブスク標準枠ではなく
+          # 「Agent SDK クレジットプール」（Max 5xで$100相当/月）から消費される。
+          # anthropic_api_key は意図的に設定しない。設定するとクレジット枠を超過した際に
+          # API従量課金へフォールバックしてしまうため。枠を超えたら実行を停止させる方針
+          # （= 予期せぬ追加課金ゼロ）。リポジトリSecretsに ANTHROPIC_API_KEY を追加しないこと。
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--allowedTools Edit,Write,\"Bash(git commit:*)\",\"Bash(git add:*)\",Read,Glob,WebSearch,WebFetch"
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,26 @@ changelogの該当項目を英語で記載
 - `CLAUDE_CODE_OAUTH_TOKEN`: Claude Code Action用のOAuthトークン（Secretsに設定）
 - `PAT_TOKEN`: GitHub Personal Access Token（リポジトリへのpush権限が必要）
 
+### 課金とサブスクリプションについて（重要）
+
+**2026-06-15以降、Anthropicのサブスクは2つの独立した課金プールに分割されました。**
+
+| プール | 対象 | このプロジェクト |
+| --- | --- | --- |
+| Pool 1（インタラクティブ＝従来のサブスク枠） | Web/デスクトップ/モバイルのチャット、ターミナル/IDEで人が対話的に使うClaude Code | ローカルで手動実行する場合 |
+| Pool 2（Agent SDK クレジットプール） | `claude -p`（ヘッドレス）、Agent SDK、**GitHub Actions** | **本リポジトリの自動ワークフロー** |
+
+GitHub Actions経由のClaude Code実行は、OAuthトークンを使っていてもPool 2（Agent SDKクレジットプール）から消費されます。これは**コードの書き方では回避できないAnthropic側のポリシー**です（`claude -p` をローカルcronに移しても同じくPool 2課金になります）。
+
+**ただし追加の出費は発生しない構成になっています：**
+
+- Pool 2にはサブスク額相当の月次クレジットが付与されます（Max 5x: $100相当/月、Max 20x: $200相当/月）。本システムは「1日1回、changelog差分がある時だけ記事生成」という軽量ワークロードのため、このクレジット枠に十分収まる見込みです。
+- リポジトリSecretsに **`ANTHROPIC_API_KEY` を設定していない**ため、クレジット枠を使い切ってもAPI従量課金へフォールバックせず、その月のActions実行が停止するだけです（＝予期せぬ追加課金ゼロ）。
+
+> ⚠️ **`ANTHROPIC_API_KEY` をSecretsに追加しないこと。** 追加するとクレジット枠超過時にAPI従量課金が発生します。認証は `CLAUDE_CODE_OAUTH_TOKEN`（サブスク）のみで行います。
+
+厳密にPool 1（従来のサブスク標準枠）だけで運用したい場合は、自動化を諦め、差分検出のみをローカルcronで行い、記事生成は自分のターミナル/IDEでClaude Codeを対話的に起動して実行する必要があります。
+
 ### スケジュール
 
 デフォルトでは毎日22:00 UTC（JST 07:00）に実行されます。


### PR DESCRIPTION
## 概要

2026-06-15のAnthropicサブスク課金分割（Pool 1: インタラクティブ枠 / Pool 2: Agent SDKクレジットプール）に対応。GitHub Actions経由のClaude Code実行はOAuthトークンでもPool 2から消費されるが、`ANTHROPIC_API_KEY` を設定しないことで枠超過時のAPI従量課金フォールバックを構造的に防ぐ。

## 変更内容
- `monitor-changelog.yml` / `claude.yml`: 課金ガードコメント追加
- `README.md`: 課金とサブスクリプションについてのセクション新設

🤖 Generated with [Claude Code](https://claude.com/claude-code)